### PR TITLE
#50 - api 서비스들의 시큐리티 설정 업데이트

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()//정적 리소스를 허용
+                                .requestMatchers("/api/**").permitAll()
                                 .requestMatchers(
                                         HttpMethod.GET
                                         , "/"
@@ -53,6 +54,7 @@ public class SecurityConfig {
                                 .userService(oAuth2UserService)
                         )
                 )
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
                 .build();
     }
 


### PR DESCRIPTION
외부 서비스인 어드민 프로젝트에서 원활하게 게시판 서비스의 api를 이용할 수 있도록 보안 설정을 수정

* csrf 인증을 api 통신일 때만 비활성화
* api 요청은 인증 없이 가능

This closes #50 